### PR TITLE
Fix a bug that doesn't scroll to the desired tab if you quickly tap different tabs.

### DIFF
--- a/Sources/ACTabScrollView.swift
+++ b/Sources/ACTabScrollView.swift
@@ -406,10 +406,10 @@ public class ACTabScrollView: UIView, UIScrollViewDelegate {
                     
                     if let tab = self.cachedPageTabs[i] {
                         if (animated) {
-                            UIView.animateWithDuration(NSTimeInterval(0.5), animations: { () in
+                            UIView.animateWithDuration(0.5, delay: 0, options: UIViewAnimationOptions.AllowUserInteraction, animations: {
                                 tab.alpha = alpha
                                 return
-                            })
+                            }, completion: nil)
                         } else {
                             tab.alpha = alpha
                         }


### PR DESCRIPTION
If a user taps on a tab, the desired tab animates to become at the center of the tab view.
If the user taps on another tab just IMMEDIATELY after the new tab is at center, nothing happens.
This is caused by the fade animation causing a block in responding to UI events.
The solution was to add the option UIViewAnimationOptions.AllowUserInteraction so that the tab responds to tap gestures.
